### PR TITLE
Pushes references to data::kDATA_TYPE_MAX and other enum values out of header and into cxx files

### DIFF
--- a/UserDev/BasicTool/FhiclLite/GNUmakefile
+++ b/UserDev/BasicTool/FhiclLite/GNUmakefile
@@ -3,7 +3,7 @@
 #
 
 # specific names for this package
-DICT  = FhiclLiteCint
+DICT = BasicTool_FhiclLiteDict
 SHLIB = libBasicTool_FhiclLite.so
 SOURCES = $(filter-out $(DICT).cxx, $(wildcard *.cxx))
 FMWK_HEADERS = LinkDef.h $(DICT).h

--- a/core/DataFormat/PiZeroROI.cxx
+++ b/core/DataFormat/PiZeroROI.cxx
@@ -6,6 +6,11 @@
 
 namespace larlite{
 
+  PiZeroROI::PiZeroROI() : data_base(data::kPiZeroROI)
+  { 
+    clear_data(); 
+  }
+  
   void PiZeroROI::clear_data(){
     _t_range.clear();
     _wire_range.clear();
@@ -217,7 +222,10 @@ namespace larlite{
   
   std::vector < std::pair< int, int > > PiZeroROI::GetPiZeroTimeROI() const { return _pi0_t_range; }
   
-  
+  event_PiZeroROI::event_PiZeroROI(std::string name) : event_base(data::kPiZeroROI,name) 
+  {
+    clear_data(); 
+  } 
   
 }
 

--- a/core/DataFormat/PiZeroROI.h
+++ b/core/DataFormat/PiZeroROI.h
@@ -22,12 +22,12 @@ namespace larlite{
   {
     
   public:
-    
+   
+    PiZeroROI();
+ 
     /// Default destructor
     virtual ~PiZeroROI(){};
-    
-  PiZeroROI() : data_base(data::kPiZeroROI)
-      { clear_data(); }
+   
     
     PiZeroROI(const std::vector < std::pair< int, int > > Wire,
           const std::vector < std::pair< int, int > > Time);
@@ -95,7 +95,8 @@ namespace larlite{
   public:
     
     /// Default constructor
-    event_PiZeroROI(std::string name="noname") : event_base(data::kPiZeroROI,name) { clear_data(); }
+    event_PiZeroROI(std::string name="noname");
+    //event_PiZeroROI(std::string name="noname") : event_base(data::kPiZeroROI,name) { clear_data(); }
     
     /// Default copy constructor
     event_PiZeroROI(const event_PiZeroROI& original) : std::vector<larlite::PiZeroROI>(original), event_base(original)

--- a/core/DataFormat/auxsimch.cxx
+++ b/core/DataFormat/auxsimch.cxx
@@ -147,5 +147,10 @@ namespace larlite{
     return (fAuxDetID == other.AuxDetID() && fAuxDetSensitiveID == other.AuxDetSensitiveID()); 
   }
 
+  event_auxsimch::event_auxsimch( std::string name ) : event_base(data::kAuxDetSimChannel,name) 
+  {
+    clear_data();
+  }
+
   
 }//namespace sim

--- a/core/DataFormat/auxsimch.h
+++ b/core/DataFormat/auxsimch.h
@@ -118,7 +118,8 @@ namespace larlite {
   public:
     
     /// Default constructor
-    event_auxsimch(std::string name="noname") : event_base(data::kAuxDetSimChannel,name) {clear_data();}
+    event_auxsimch(std::string name="noname");
+    //event_auxsimch(std::string name="noname") : event_base(data::kAuxDetSimChannel,name) {clear_data();}
     
     /// Default copy constructor
     event_auxsimch(const event_auxsimch& original)

--- a/core/DataFormat/calorimetry.cxx
+++ b/core/DataFormat/calorimetry.cxx
@@ -5,6 +5,11 @@
 
 namespace larlite {
 
+  calorimetry::calorimetry() : data_base(data::kCalorimetry) 
+  {
+    clear_data();
+  } 
+
   //*************************************
   void calorimetry::clear_data() 
   //*************************************
@@ -16,6 +21,11 @@ namespace larlite {
     fDeadWireResR.clear();
     fTrkPitch.clear();
     fRange = -1;
+  }
+
+  event_calorimetry::event_calorimetry(std::string name) : event_base(data::kCalorimetry,name)
+  {
+    clear_data();
   }
 
 }

--- a/core/DataFormat/calorimetry.h
+++ b/core/DataFormat/calorimetry.h
@@ -28,7 +28,8 @@ namespace larlite{
   public:
     
     /// Default constructor
-    calorimetry() : data_base(data::kCalorimetry) {clear_data();}
+    //calorimetry() : data_base(data::kCalorimetry) {clear_data();}
+    calorimetry();
 
     /// Copy constructor
     calorimetry(const calorimetry& original) : data_base(original),
@@ -103,8 +104,9 @@ namespace larlite{
   public:
     
     /// Default constructor
-    event_calorimetry(std::string name="noname") : event_base(data::kCalorimetry,name) {clear_data();}
-    
+    //event_calorimetry(std::string name="noname") : event_base(data::kCalorimetry,name) {clear_data();}
+    event_calorimetry(std::string name="noname");
+
     /// Default copy constructor
     event_calorimetry(const event_calorimetry& original) : std::vector<larlite::calorimetry>(original),
 							   event_base(original)

--- a/core/DataFormat/chstatus.cxx
+++ b/core/DataFormat/chstatus.cxx
@@ -13,6 +13,11 @@ namespace larlite{
 
   void chstatus::set_status(const geo::PlaneID& plane, std::vector<short>&& status_v)
   { fPlaneID = plane; fStatus_v = std::move(status_v); }
+
+  event_chstatus::event_chstatus(std::string name) : event_base(data::kChStatus,name) 
+  { 
+    clear_data();
+  }
   
 }
 

--- a/core/DataFormat/chstatus.h
+++ b/core/DataFormat/chstatus.h
@@ -64,7 +64,7 @@ namespace larlite {
   public:
 
     /// Default constructor
-    event_chstatus(std::string name="noname") : event_base(data::kChStatus,name) { clear_data();}
+    event_chstatus(std::string name="noname");
     
     /// Default copy constructor
     event_chstatus(const event_chstatus& original) : std::vector<larlite::chstatus>(original),

--- a/core/DataFormat/cluster.cxx
+++ b/core/DataFormat/cluster.cxx
@@ -5,6 +5,11 @@
 
 namespace larlite{
 
+  cluster::cluster() : data_base(data::kCluster) 
+  {
+    clear_data();
+  }
+
   void cluster::clear_data()
   {
     data_base::clear_data();
@@ -89,6 +94,11 @@ namespace larlite{
     
     return false; // they are equal enough
   } // operator < (Cluster, Cluster)
+
+  event_cluster::event_cluster(std::string name) : event_base(data::kCluster,name)
+  {
+    clear_data();
+  }
   
 }
 

--- a/core/DataFormat/cluster.h
+++ b/core/DataFormat/cluster.h
@@ -46,7 +46,8 @@ namespace larlite{
   public:
     
     /// Default constructor
-    cluster() : data_base(data::kCluster) { clear_data(); }
+    //cluster() : data_base(data::kCluster) { clear_data(); }
+    cluster();
     
     /// Default destructor
     virtual ~cluster(){}
@@ -681,8 +682,9 @@ namespace larlite{
   public:
     
     /// Default constructor
-    event_cluster(std::string name="noname") : event_base(data::kCluster,name) {clear_data();}
-    
+			  //event_cluster(std::string name="noname") : event_base(data::kCluster,name) {clear_data();}
+    event_cluster(std::string name="noname");
+			  
     /// Default copy constructor
     event_cluster(const event_cluster& original)
       : std::vector<larlite::cluster>(original), event_base(original)

--- a/core/DataFormat/data_base.cxx
+++ b/core/DataFormat/data_base.cxx
@@ -8,7 +8,8 @@ namespace larlite {
   //
   // data_base
   //
-  
+  data_base::data_base() : _type( data::kDATA_TYPE_MAX ) { clear_data(); }
+
   data_base::data_base(unsigned short type)
     : _type(type)
   { clear_data(); }
@@ -19,6 +20,7 @@ namespace larlite {
   //
   // output_base
   //
+  output_base::output_base() : data_base(data::kDATA_TYPE_MAX), _id(data::kDATA_TYPE_MAX,"noname") { clear_data(); }
 
   output_base::output_base(unsigned short type,
 			   const std::string name)
@@ -95,7 +97,7 @@ namespace larlite {
   //
   // event_base
   //
-
+  event_base::event_base() : output_base(data::kDATA_TYPE_MAX,"noname") { clear_data(); }
   event_base::event_base(unsigned short    type,
 			 const std::string name)
     : output_base(type,name)

--- a/core/DataFormat/data_base.h
+++ b/core/DataFormat/data_base.h
@@ -33,7 +33,8 @@ namespace larlite{
   public:
     
     /// Default constructor
-    data_base(unsigned short type = data::kDATA_TYPE_MAX);
+    data_base();
+    data_base(unsigned short type);// = data::kDATA_TYPE_MAX);
 
     /// Default copy constructor to avoid memory leak in ROOT streamer
     data_base(const data_base &original) : _type(original._type) {}
@@ -63,7 +64,8 @@ namespace larlite{
   class output_base : public data_base {
   public:
     /// Default ctor
-    output_base(unsigned short type = data::kDATA_TYPE_MAX,
+    output_base();
+    output_base(unsigned short type,// = data::kDATA_TYPE_MAX,
 		const std::string name = "noname");
     /// Copy ctor
     output_base(const output_base& orig);
@@ -167,7 +169,8 @@ namespace larlite{
   public:
     
     /// Default constructor
-    event_base(unsigned short    type = data::kDATA_TYPE_MAX,
+    event_base();
+    event_base(unsigned short    type,// = data::kDATA_TYPE_MAX,
 	       const std::string name = "noname");
     
     /// Default copy constructor to avoid memory leak in ROOT streamer

--- a/core/DataFormat/larlite_dataformat_utils.cxx
+++ b/core/DataFormat/larlite_dataformat_utils.cxx
@@ -1,0 +1,7 @@
+#include "larlite_dataformat_utils.h"
+
+namespace larlite {
+  
+  product_id::product_id() : std::pair<unsigned short,std::string>(larlite::data::kDATA_TYPE_MAX,"noname") {};
+  
+}

--- a/core/DataFormat/larlite_dataformat_utils.h
+++ b/core/DataFormat/larlite_dataformat_utils.h
@@ -48,7 +48,8 @@ namespace larlite{
   public:
 
     /// Default ctor
-    product_id(const unsigned short type = larlite::data::kDATA_TYPE_MAX,
+    product_id();
+    product_id(const unsigned short type,// = larlite::data::kDATA_TYPE_MAX,
 	       const std::string name = "noname")
       : std::pair<unsigned short,std::string>(type,name)
     {}

--- a/core/DataFormat/vertex.cxx
+++ b/core/DataFormat/vertex.cxx
@@ -5,6 +5,8 @@
 
 namespace larlite {
 
+  vertex::vertex() : data_base(data::kVertex) {clear_data();}
+
   //************************************************************
   vertex::vertex(Double_t* xyz,
 		 Int_t      id)
@@ -41,6 +43,15 @@ namespace larlite {
   double vertex::X() const { return fXYZ[0]; }
   double vertex::Y() const { return fXYZ[1]; }
   double vertex::Z() const { return fXYZ[2]; }
+
+
+  event_vertex::event_vertex(std::string name) : event_base(data::kVertex,name) 
+  {
+    clear_data();
+  }
+
 }
+
+
 
 #endif

--- a/core/DataFormat/vertex.h
+++ b/core/DataFormat/vertex.h
@@ -27,7 +27,7 @@ namespace larlite {
   public:
     
     /// Default constructor
-    vertex() : data_base(data::kVertex) {clear_data();}
+    vertex();
 
     /// Alternative constructor
     vertex(double* xyz,
@@ -68,7 +68,7 @@ namespace larlite {
   public:
     
     /// Default constructor
-    event_vertex(std::string name="noname") : event_base(data::kVertex,name) {clear_data();}
+    event_vertex(std::string name="noname");
     
     /// Default copy constructor
     event_vertex(const event_vertex& original) : std::vector<larlite::vertex>(original),


### PR DESCRIPTION
These edits are in response to the following error:

```
/Users/twongjirad/working/uboone/larlite/core/DataFormat/larlite_dataformat_utils.h:51:59: error: no member named 'kDATA_TYPE_MAX' in namespace 'larlite::data'
    product_id(const unsigned short type = larlite::data::kDATA_TYPE_MAX,
                                           ~~~~~~~~~~~~~~~^
In file included from libLArCVDataFormat dictionary payload:7:
In file included from /Users/twongjirad/working/uboone/larlite/core/DataFormat/ChStatus.h:22:
/Users/twongjirad/working/uboone/larlite/core/DataFormat/data_base.h:36:43: error: no member named 'kDATA_TYPE_MAX' in namespace 'larlite::data'
    data_base(unsigned short type = data::kDATA_TYPE_MAX);
                                    ~~~~~~^
/Users/twongjirad/working/uboone/larlite/core/DataFormat/data_base.h:66:45: error: no member named 'kDATA_TYPE_MAX' in namespace 'larlite::data'
    output_base(unsigned short type = data::kDATA_TYPE_MAX,
                                      ~~~~~~^
/Users/twongjirad/working/uboone/larlite/core/DataFormat/data_base.h:170:47: error: no member named 'kDATA_TYPE_MAX' in namespace 'larlite::data'
    event_base(unsigned short    type = data::kDATA_TYPE_MAX,
                                        ~~~~~~^
In file included from libLArCVDataFormat dictionary payload:24:
/Users/twongjirad/working/uboone/larlite/core/DataFormat/Vertex.h:30:32: error: no member named 'kVertex' in namespace 'larlite::data'
    vertex() : data_base(data::kVertex) {clear_data();}
                         ~~~~~~^
/Users/twongjirad/working/uboone/larlite/core/DataFormat/Vertex.h:71:64: error: no member named 'kVertex' in namespace 'larlite::data'
    event_vertex(std::string name="noname") : event_base(data::kVertex,name) {clear_data();}
                                                         ~~~~~~^
Error in <TInterpreter::AutoParse>: Error parsing payload code for class larcv::ChStatus with content:

#line 1 "
```

By creating a default constructor explicitly, I am able to remove references to enum values into the class definitions.  This seemed to help.
