### PR TITLE
Tmw choose photonlibrary

### DIFF
--- a/UserDev/SelectionTool/OpT0Finder/Algorithms/PhotonLibHypothesis.cxx
+++ b/UserDev/SelectionTool/OpT0Finder/Algorithms/PhotonLibHypothesis.cxx
@@ -16,8 +16,8 @@ namespace flashana {
   {
     _global_qe = pset.get<double>("GlobalQE");
     _qe_v      = pset.get<std::vector<double> >("CCVCorrection");
-    _libraryfile = pset.get<std::string>("LibraryFile","__PHOTONLIB_FILE_NOT_SET__");
-    if (_libraryfile=="__PHOTONLIB_FILE_NOT_SET__")
+    _libraryfile = pset.get<std::string>("LibraryFile","");
+    if (_libraryfile.empty())
       fLibrarySet = false;
     else
       fLibrarySet = true;

--- a/UserDev/SelectionTool/OpT0Finder/Algorithms/PhotonLibHypothesis.cxx
+++ b/UserDev/SelectionTool/OpT0Finder/Algorithms/PhotonLibHypothesis.cxx
@@ -16,6 +16,11 @@ namespace flashana {
   {
     _global_qe = pset.get<double>("GlobalQE");
     _qe_v      = pset.get<std::vector<double> >("CCVCorrection");
+    _libraryfile = pset.get<std::string>("LibraryFile","__PHOTONLIB_FILE_NOT_SET__");
+    if (_libraryfile=="__PHOTONLIB_FILE_NOT_SET__")
+      fLibrarySet = false;
+    else
+      fLibrarySet = true;
     if(_qe_v.size() != NOpDets()) {
       FLASH_CRITICAL() << "CCVCorrection factor array has size " << _qe_v.size()
 		       << " != number of opdet (" << NOpDets() << ")!" << std::endl;
@@ -28,6 +33,11 @@ namespace flashana {
   {
     
     size_t n_pmt = BaseAlgorithm::NOpDets();//n_pmt returns 0 now, needs to be fixed
+    const ::phot::PhotonVisibilityService*  pPhotonLib = NULL;
+    if ( fLibrarySet )
+      pPhotonLib = &(::phot::PhotonVisibilityService::GetME());
+    else
+      pPhotonLib = &(::phot::PhotonVisibilityService::GetME(_libraryfile));
     
     for ( auto& v : flash.pe_v ) v = 0;
     
@@ -39,13 +49,13 @@ namespace flashana {
 	
         double q = pt.q;
 	
-        q *= ::phot::PhotonVisibilityService::GetME().GetVisibility( pt.x, pt.y, pt.z, ipmt) * _global_qe / _qe_v[ipmt];
+        q *= pPhotonLib->GetVisibility( pt.x, pt.y, pt.z, ipmt) * _global_qe / _qe_v[ipmt];
         flash.pe_v[ipmt] += q;
 	//std::cout << "PMT : " << ipmt << " [x,y,z] -> [q] : [" << pt.x << ", " << pt.y << ", " << pt.z << "] -> [" << q << std::endl;
 	
       }
     }
-
+    
     return;
   }
 }

--- a/UserDev/SelectionTool/OpT0Finder/Algorithms/PhotonLibHypothesis.h
+++ b/UserDev/SelectionTool/OpT0Finder/Algorithms/PhotonLibHypothesis.h
@@ -42,6 +42,8 @@ namespace flashana {
 
     double _global_qe;         ///< Global QE
     std::vector<double> _qe_v; ///< PMT-wise relative QE
+    std::string _libraryfile;
+    bool fLibrarySet;
   };
   
   /**

--- a/UserDev/SelectionTool/OpT0Finder/PhotonLibrary/PhotonVisibilityService.cxx
+++ b/UserDev/SelectionTool/OpT0Finder/PhotonLibrary/PhotonVisibilityService.cxx
@@ -100,20 +100,30 @@ namespace phot{
 
 
       if((!fLibraryBuildJob)&&(!fDoNotLoadLibrary)) {
-	std::string LibraryFileWithPath = std::string(getenv("LARLITE_USERDEVDIR"));
-	LibraryFileWithPath += "/SelectionTool/OpT0Finder/PhotonLibrary/dat/";
-	LibraryFileWithPath += fLibraryFile;
+
+	std::string LibraryFileWithPath;
+	if ( fLibraryFile.front()!='/' ) {
+	  // relative path provided. use designated folder in larlite
+	  LibraryFileWithPath = std::string(getenv("LARLITE_USERDEVDIR"));
+	  LibraryFileWithPath += "/SelectionTool/OpT0Finder/PhotonLibrary/dat/";
+	  LibraryFileWithPath += fLibraryFile;
+	}
+	else {
+	  // absolute path
+	  LibraryFileWithPath = fLibraryFile;
+	}
 	if(!fParameterization) {
 	  std::cout << "PhotonVisibilityService Loading photon library from file "
 		    << LibraryFileWithPath
 		    << std::endl;
 	  size_t NVoxels = GetVoxelDef().GetNVoxels();
 	  fTheLibrary->LoadLibraryFromFile(LibraryFileWithPath, NVoxels);
-	}
+	} 
       }
       else {
+	// building library, so creating an empty one
         //art::ServiceHandle<geo::Geometry> geom;
-
+	
         size_t NVoxels = GetVoxelDef().GetNVoxels();
 	std::cout << " Vis service running library build job.  Please ensure " 
 		  << " job contains LightSource, LArG4, SimPhotonCounter"<<std::endl;

--- a/UserDev/SelectionTool/OpT0Finder/PhotonLibrary/PhotonVisibilityService.h
+++ b/UserDev/SelectionTool/OpT0Finder/PhotonLibrary/PhotonVisibilityService.h
@@ -54,11 +54,17 @@ namespace phot{
     bool UseParameterization() const {return fParameterization;}
 
     sim::PhotonVoxelDef GetVoxelDef() const {return fVoxelDef; }
-    int NOpChannels() const { return fNOpDetChannels; } 
+    int NOpChannels() const { return fNOpDetChannels; }
 
-    static PhotonVisibilityService& GetME()
+    std::string GetLibraryFilename() { return fLibraryFile; }; // Allows one to check loaded filename
+
+    static PhotonVisibilityService& GetME(std::string filename="uboone_photon_library_v6_efield.root")
     {
-      if(!_me) _me = new PhotonVisibilityService;
+      // argument allows user to choose file loaded
+      // if relative, searches for file in designated folder
+      // if absolute, searches for file with given path
+      // see LoadLibrary()
+      if(!_me) _me = new PhotonVisibilityService(filename);
       return *_me;
     }
     

--- a/UserDev/SelectionTool/OpT0Finder/PhotonLibrary/PhotonVisibilityService.h
+++ b/UserDev/SelectionTool/OpT0Finder/PhotonLibrary/PhotonVisibilityService.h
@@ -56,7 +56,7 @@ namespace phot{
     sim::PhotonVoxelDef GetVoxelDef() const {return fVoxelDef; }
     int NOpChannels() const { return fNOpDetChannels; }
 
-    std::string GetLibraryFilename() { return fLibraryFile; }; // Allows one to check loaded filename
+    const std::string& GetLibraryFilename() { return fLibraryFile; }; // Allows one to check loaded filename
 
     static PhotonVisibilityService& GetME(std::string filename="uboone_photon_library_v6_efield.root")
     {


### PR DESCRIPTION
The edits allow the user to load a different photon library file and using any path, not just the designated folder in SelectionTool/OpT0Finder/PhotonLibrary/dat. Though one can use that folder if they want.  One can load the PhotonVisibilityService static pointer instance using GetME("filepath"). GetME() uses default like past behavior.

PhotonLibHypothesis class now has fcl parameter to set library using these methods.