### PR TITLE
Switch to using clang to link for c2.

### DIFF
--- a/Makefile/Makefile.Linux
+++ b/Makefile/Makefile.Linux
@@ -1,9 +1,9 @@
 
 CXX		= $(LARLITE_CXX)
-LD              = g++
+LD              = $(LARLITE_CXX)
 LDFLAGS         += -Wl,-rpath,$(LARLITE_BASEDIR)/lib
 FFLAGS          += -Wall
 FLDFLAGS        += -lstdc++ -shared 
 CXXFLAGS        += -g -O3 $(LARLITE_CXXSTDFLAG) -W -Wall -Wno-deprecated -fPIC -D_CORE_$(shell uname -s)_
-SOMAKER         = g++
+SOMAKER         = $(LARLITE_CXX)
 SOFLAGS         = -g -fPIC -shared


### PR DESCRIPTION
For larlite v06_70_00g